### PR TITLE
Make regex a lot less generic/eager

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -6,7 +6,7 @@ function wegMetDieNaam() {
       var node = element.childNodes[j];
       if (node.nodeType === 3) {
         var text = node.nodeValue;
-        var regEx = new RegExp("lil(.*)kleine", "igm");
+        var regEx = new RegExp("lil[ \t\r\n\v\f'`]{1,4}kleine", "igm");
         var replacedText = text.replace(regEx, "Pauperkabouter");
         if (replacedText !== text) {
           element.replaceChild(document.createTextNode(replacedText), node);


### PR DESCRIPTION
Hopefully this may help. Instead of matching basically anything starting with "lil" and ending with "kleine" (including 3 Kb of text with "Lil Kleine" both near the beginning and near the end of it..), this should only match strings consisting of "lil", followed by 1, 2, 3, or 4 characters from the class of "either whitespace, or one of both possible ASCII characters for a single quote", following by "kleine". Much less change of matching multiple instances of the dreaded name in a longer piece of text that way. Just be sure you replace all matches of the regex, also in a longer text. And this this first; I just did a theoretical change of the regex in the github.com website based editor without testing anything here... Good luck!